### PR TITLE
Workflow os specific

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
       # Checkout submodules (required for fever module used in app update system)

--- a/.github/workflows/build_installer.yml
+++ b/.github/workflows/build_installer.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
       # Checkout submodules (required for fever module used in app update system)

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
     temp-build:
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-20.04
       steps:
       - run: |
           echo Pull Request build disabled until faster build process is implemented.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   versioning:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       # Get latest released version
       - uses: oprypin/find-latest-tag@v1
@@ -45,7 +45,7 @@ jobs:
 
   build:
     needs: [versioning]
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
       # Checkout submodules (required for fever module used in app update system)
@@ -130,7 +130,7 @@ jobs:
 
   deploy:
     needs: [build]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       # Get project version
@@ -200,7 +200,7 @@ jobs:
   
   cleanup:
     needs: [deploy]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       # Cleanup artifacts used for job sharing


### PR DESCRIPTION
Use specific os in workflows for increased stability:
- ubuntu-latest -> ubuntu-20.04
- windows-latest -> windows-2019

This was required as new windows-2022 version will replace windows-latest soon.